### PR TITLE
[#17] [#18] [Integration] PART 1 - As a signed-in user, I can see horizontal scrollable list of survey and pull down to refresh survey list on the Home screen 

### DIFF
--- a/lib/ui/home/home_footer_widget.dart
+++ b/lib/ui/home/home_footer_widget.dart
@@ -54,7 +54,7 @@ class HomeFooterWidget extends StatelessWidget {
           ),
           onPressed: () {
             var params = <String, String>{};
-            params[RoutePath.surveyDetails.pathParam] = _survey?.id ?? '';
+            params[RoutePath.surveyDetails.pathParam] = survey.id;
             context.pushNamed(RoutePath.surveyDetails.name, params: params);
           },
         ),

--- a/lib/ui/home/home_footer_widget.dart
+++ b/lib/ui/home/home_footer_widget.dart
@@ -7,50 +7,68 @@ import 'package:survey_flutter_ic/utils/route_path.dart';
 import '../../model/survey_model.dart';
 
 class HomeFooterWidget extends StatelessWidget {
-  final SurveyModel? _survey;
+  final List<SurveyModel> surveys;
+  final PageController pageController;
+  final Function(int) onPageChangedCallback;
 
-  const HomeFooterWidget(this._survey, {super.key});
+  const HomeFooterWidget({
+    required this.surveys,
+    required this.pageController,
+    required this.onPageChangedCallback,
+    super.key,
+  });
 
-  @override
-  Widget build(BuildContext context) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
+  Widget footerWidget(BuildContext context, SurveyModel survey) {
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.end,
       children: [
-        Text(
-          _survey?.title ?? '',
-          style: context.textTheme.displayMedium,
-          maxLines: 2,
-        ),
-        const SizedBox(height: Dimensions.paddingNormal),
-        Row(
-          children: [
-            Expanded(
-              child: Text(
-                _survey?.description ?? '',
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            mainAxisAlignment: MainAxisAlignment.end,
+            children: [
+              Text(
+                survey.title,
+                style: context.textTheme.displayMedium,
+                maxLines: 2,
+              ),
+              const SizedBox(height: Dimensions.paddingNormal),
+              Text(
+                survey.description,
                 style: context.textTheme.bodyMedium,
                 maxLines: 2,
               ),
-            ),
-            ElevatedButton(
-              style: ElevatedButton.styleFrom(
-                shape: const CircleBorder(),
-                backgroundColor: Colors.white,
-                foregroundColor: Colors.black26,
-                padding: const EdgeInsets.all(Dimensions.paddingNormal),
-              ),
-              child: const Icon(
-                Icons.navigate_next,
-                color: Colors.black,
-              ),
-              onPressed: () {
-                var params = <String, String>{};
-                params[RoutePath.surveyDetails.pathParam] = _survey?.id ?? '';
-                context.pushNamed(RoutePath.surveyDetails.name, params: params);
-              },
-            ),
-          ],
+            ],
+          ),
+        ),
+        ElevatedButton(
+          style: ElevatedButton.styleFrom(
+            shape: const CircleBorder(),
+            backgroundColor: Colors.white,
+            foregroundColor: Colors.black26,
+            padding: const EdgeInsets.all(Dimensions.paddingNormal),
+          ),
+          child: const Icon(
+            Icons.navigate_next,
+            color: Colors.black,
+          ),
+          onPressed: () {
+            var params = <String, String>{};
+            params[RoutePath.surveyDetails.pathParam] = _survey?.id ?? '';
+            context.pushNamed(RoutePath.surveyDetails.name, params: params);
+          },
         ),
       ],
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return PageView.builder(
+      controller: pageController,
+      itemCount: surveys.length,
+      onPageChanged: (index) => onPageChangedCallback(index),
+      itemBuilder: (_, index) => footerWidget(context, surveys[index]),
     );
   }
 }

--- a/lib/ui/home/home_screen.dart
+++ b/lib/ui/home/home_screen.dart
@@ -9,6 +9,7 @@ import 'package:survey_flutter_ic/ui/home/home_side_menu.dart';
 import 'package:survey_flutter_ic/ui/home/home_side_menu_ui_model.dart';
 import 'package:survey_flutter_ic/ui/home/home_state.dart';
 import 'package:survey_flutter_ic/ui/home/home_view_model.dart';
+import 'package:survey_flutter_ic/ui/home/loading/home_skeleton_loading.dart';
 import 'package:survey_flutter_ic/utils/dimension.dart';
 
 import '../../di/di.dart';
@@ -63,11 +64,9 @@ class HomeScreenState extends ConsumerState<HomeScreen> {
       );
 
   Widget _homeBackground(List<SurveyModel> surveys, int focusedIndex) {
-    if (surveys.isEmpty) {
-      return _emptyBackground;
-    } else {
-      return _imageBackground(surveys[focusedIndex]);
-    }
+    return surveys.isEmpty
+        ? _emptyBackground
+        : _imageBackground(surveys[focusedIndex]);
   }
 
   Widget _homeHeaderWidget() {
@@ -129,9 +128,8 @@ class HomeScreenState extends ConsumerState<HomeScreen> {
                         height: MediaQuery.of(context).size.height -
                             MediaQuery.of(context).viewPadding.vertical,
                         child: Container(
-                          padding: const EdgeInsets.all(
-                            Dimensions.paddingMedium,
-                          ),
+                          padding:
+                              const EdgeInsets.all(Dimensions.paddingMedium),
                           child: Stack(
                             children: [
                               _homeHeaderWidget(),
@@ -150,7 +148,7 @@ class HomeScreenState extends ConsumerState<HomeScreen> {
           Visibility(
             visible: surveys.isEmpty,
             child: const SafeArea(
-              child: HomeLoading(),
+              child: HomeSkeletonLoading(),
             ),
           ),
         ],

--- a/lib/ui/home/home_view_model.dart
+++ b/lib/ui/home/home_view_model.dart
@@ -28,6 +28,7 @@ class HomeViewModel extends StateNotifier<HomeState> {
   final GetSurveysUseCase getSurveysUseCase;
 
   _LoadMoreDataSet _loadMoreDataSet = _LoadMoreDataSet();
+  final List<SurveyModel> _totalSurveys = List.empty(growable: true);
 
   HomeViewModel({required this.getSurveysUseCase})
       : super(const HomeState.init());
@@ -35,11 +36,11 @@ class HomeViewModel extends StateNotifier<HomeState> {
   void getSurveys({bool isRefresh = false}) async {
     if (isRefresh) {
       _loadMoreDataSet = _LoadMoreDataSet();
+      _totalSurveys.clear();
     }
 
     if (!_loadMoreDataSet.isHasMore || _loadMoreDataSet.isLoading) return;
     _loadMoreDataSet.isLoading = true;
-
     final result = await getSurveysUseCase.call(SurveysParams(
       pageNumber: _loadMoreDataSet.page,
       pageSize: _loadMoreDataSet.pageSize,
@@ -47,7 +48,8 @@ class HomeViewModel extends StateNotifier<HomeState> {
     if (result is Success<SurveysModel>) {
       final newSurveys = result.value.surveys;
       calculateLoadMoreDataSet(result.value.meta);
-      _surveysStream.add(newSurveys);
+      _totalSurveys.addAll(newSurveys);
+      _surveysStream.add(_totalSurveys);
     } else {
       state = HomeState.error(NetworkExceptions.getErrorMessage(
           (result as Failed).exception.actualException));

--- a/lib/ui/home/home_view_model.dart
+++ b/lib/ui/home/home_view_model.dart
@@ -33,9 +33,10 @@ class HomeViewModel extends StateNotifier<HomeState> {
   HomeViewModel({required this.getSurveysUseCase})
       : super(const HomeState.init());
 
-  void getSurveys({bool isRefresh = false}) async {
+  Future<void> getSurveys({bool isRefresh = false}) async {
     if (isRefresh) {
       _loadMoreDataSet = _LoadMoreDataSet();
+      _focusedItemIndexStream.add(0);
       _totalSurveys.clear();
     }
 


### PR DESCRIPTION
- Close #17 #18 

## What happened 👀

- This is part one of integrating the horizontally scrollable list and pull down to refresh list on Home screen
- Refactor widgets of home screen for easier to handle page view inside pull down to refresh widget.
- Use `Visibility` widget to handle loading cases

## Insight 📝

- Use `Visibility`  widfor smoother effect when switching between skeleton loading view and home widget view when data is fetched
- Part two will include integrating cache surveys and unit test

## Proof Of Work 📹

[device-2023-05-09-152729.webm](https://user-images.githubusercontent.com/25218255/237039463-c7dd18c7-07dc-4a6b-a0af-1628b4f1121e.webm)

- iOS

https://user-images.githubusercontent.com/25218255/237039474-ca259a40-9d83-42cf-8ff3-b05520eb7073.mp4
