### PR TITLE
[#35] [Integration] As a user, I can submit survey's answers 

### DIFF
--- a/lib/ui/survey_question/survey_questions_screen.dart
+++ b/lib/ui/survey_question/survey_questions_screen.dart
@@ -55,7 +55,10 @@ class SurveyQuestionsScreenState extends ConsumerState<SurveyQuestionsScreen> {
       builder: (_, ref, __) {
         final state = ref.watch(surveyQuestionsViewModelProvider);
         return state.maybeWhen(
-          success: (uiModel, coverImageUrl) =>
+          submitting: _buildQuestionView,
+          submitted: _buildQuestionView,
+          success: _buildQuestionView,
+          error: (uiModel, coverImageUrl, _) =>
               _buildQuestionView(uiModel, coverImageUrl),
           orElse: () {
             return const SizedBox.shrink();
@@ -89,14 +92,14 @@ class SurveyQuestionsScreenState extends ConsumerState<SurveyQuestionsScreen> {
     ref.listen<SurveyQuestionsState>(surveyQuestionsViewModelProvider,
         (_, state) {
       state.maybeWhen(
-        submitting: () => context.displayLoadingDialog(showOrHide: true),
-        submitted: () {
+        submitting: (_, __) => context.displayLoadingDialog(showOrHide: true),
+        submitted: (_, __) {
           context.displayLoadingDialog(showOrHide: false);
           context.showLottie(
             onAnimated: () => context.pushReplacementNamed(RoutePath.home.name),
           );
         },
-        error: (error) {
+        error: (_, __, error) {
           context.displayLoadingDialog(showOrHide: false);
           context.showMessageSnackBar(
             message: '${context.localization.pleaseTryAgain} $error.',

--- a/lib/ui/survey_question/survey_questions_screen.dart
+++ b/lib/ui/survey_question/survey_questions_screen.dart
@@ -111,6 +111,7 @@ class SurveyQuestionsScreenState extends ConsumerState<SurveyQuestionsScreen> {
   }
 
   void _nextQuestion() {
+    ref.read(surveyQuestionsViewModelProvider.notifier).saveAnswer();
     context.pushReplacementNamed(
       RoutePath.surveyQuestion.name,
       params: _getPathParams(),

--- a/lib/ui/survey_question/survey_questions_state.dart
+++ b/lib/ui/survey_question/survey_questions_state.dart
@@ -7,21 +7,11 @@ part 'survey_questions_state.freezed.dart';
 class SurveyQuestionsState with _$SurveyQuestionsState {
   const factory SurveyQuestionsState.init() = _Init;
 
-  const factory SurveyQuestionsState.submitting({
-    required SurveyQuestionsUIModel uiModel,
-    required String coverImageUrl,
-  }) = _Submitting;
+  const factory SurveyQuestionsState.submitting() = _Submitting;
 
-  const factory SurveyQuestionsState.submitted({
-    required SurveyQuestionsUIModel uiModel,
-    required String coverImageUrl,
-  }) = _Submitted;
+  const factory SurveyQuestionsState.submitted() = _Submitted;
 
-  const factory SurveyQuestionsState.error({
-    required SurveyQuestionsUIModel uiModel,
-    required String coverImageUrl,
-    required String? error,
-  }) = _Error;
+  const factory SurveyQuestionsState.error({required String? error}) = _Error;
 
   const factory SurveyQuestionsState.success({
     required SurveyQuestionsUIModel uiModel,

--- a/lib/ui/survey_question/survey_questions_state.dart
+++ b/lib/ui/survey_question/survey_questions_state.dart
@@ -7,11 +7,21 @@ part 'survey_questions_state.freezed.dart';
 class SurveyQuestionsState with _$SurveyQuestionsState {
   const factory SurveyQuestionsState.init() = _Init;
 
-  const factory SurveyQuestionsState.submitting() = _Submitting;
+  const factory SurveyQuestionsState.submitting({
+    required SurveyQuestionsUIModel uiModel,
+    required String coverImageUrl,
+  }) = _Submitting;
 
-  const factory SurveyQuestionsState.submitted() = _Submitted;
+  const factory SurveyQuestionsState.submitted({
+    required SurveyQuestionsUIModel uiModel,
+    required String coverImageUrl,
+  }) = _Submitted;
 
-  const factory SurveyQuestionsState.error({required String? error}) = _Error;
+  const factory SurveyQuestionsState.error({
+    required SurveyQuestionsUIModel uiModel,
+    required String coverImageUrl,
+    required String? error,
+  }) = _Error;
 
   const factory SurveyQuestionsState.success({
     required SurveyQuestionsUIModel uiModel,

--- a/lib/ui/survey_question/survey_questions_view_model.dart
+++ b/lib/ui/survey_question/survey_questions_view_model.dart
@@ -259,15 +259,23 @@ class SurveyQuestionsViewModel extends StateNotifier<SurveyQuestionsState> {
   void submitAnswers() async {
     final result = await _getSurveySubmissionUseCase.call();
     if (result is Success<SurveySubmissionModel?>) {
-      state = const SurveyQuestionsState.submitting();
+      state = SurveyQuestionsState.submitting(
+        uiModel: uiModel,
+        coverImageUrl: _survey?.coverImageUrl ?? '',
+      );
       final submission = result.value;
       if (submission != null) {
         final result = await _submitSurveyAnswerUseCase.call(submission);
         if (result is Success<bool>) {
-          state = const SurveyQuestionsState.submitted();
-          _clearStoredCurrentSurveySubmission();
+          state = SurveyQuestionsState.submitted(
+            uiModel: uiModel,
+            coverImageUrl: _survey?.coverImageUrl ?? '',
+          );
+          await _clearStoredCurrentSurveySubmission();
         } else {
           state = SurveyQuestionsState.error(
+            uiModel: uiModel,
+            coverImageUrl: _survey?.coverImageUrl ?? '',
             error: NetworkExceptions.getErrorMessage(
               (result as Failed).exception.actualException,
             ),
@@ -277,7 +285,7 @@ class SurveyQuestionsViewModel extends StateNotifier<SurveyQuestionsState> {
     }
   }
 
-  void _clearStoredCurrentSurveySubmission() {
-    _saveSurveySubmissionUseCase.call(null);
+  Future<void> _clearStoredCurrentSurveySubmission() async {
+    await _saveSurveySubmissionUseCase.call(null);
   }
 }

--- a/lib/ui/survey_question/survey_questions_view_model.dart
+++ b/lib/ui/survey_question/survey_questions_view_model.dart
@@ -13,12 +13,16 @@ import 'package:survey_flutter_ic/usecases/base/base_use_case.dart';
 import 'package:survey_flutter_ic/usecases/get_current_survey_use_case.dart';
 import 'package:survey_flutter_ic/usecases/get_survey_submission_use_case.dart';
 import 'package:survey_flutter_ic/usecases/save_survey_submission_use_case.dart';
+import 'package:survey_flutter_ic/usecases/submit_survey_answer_use_case.dart';
 import 'package:survey_flutter_ic/utils/route_path.dart';
+
+import '../../api/exception/network_exceptions.dart';
 
 class SurveyQuestionsViewModel extends StateNotifier<SurveyQuestionsState> {
   final GetCurrentSurveyUseCase _getCurrentSurveyUseCase;
   final GetSurveySubmissionUseCase _getSurveySubmissionUseCase;
   final SaveSurveySubmissionUseCase _saveSurveySubmissionUseCase;
+  final SubmitSurveyAnswerUseCase _submitSurveyAnswerUseCase;
 
   String get _surveyIdValue => _surveyId ?? '';
   String? _surveyId;
@@ -42,6 +46,7 @@ class SurveyQuestionsViewModel extends StateNotifier<SurveyQuestionsState> {
     this._getCurrentSurveyUseCase,
     this._getSurveySubmissionUseCase,
     this._saveSurveySubmissionUseCase,
+    this._submitSurveyAnswerUseCase,
   ) : super(const SurveyQuestionsState.init());
 
   void setUpData({
@@ -251,7 +256,26 @@ class SurveyQuestionsViewModel extends StateNotifier<SurveyQuestionsState> {
     return answers;
   }
 
-  void submitAnswers() async {}
+  void submitAnswers() async {
+    final result = await _getSurveySubmissionUseCase.call();
+    if (result is Success<SurveySubmissionModel?>) {
+      state = const SurveyQuestionsState.submitting();
+      final submission = result.value;
+      if (submission != null) {
+        final result = await _submitSurveyAnswerUseCase.call(submission);
+        if (result is Success<bool>) {
+          state = const SurveyQuestionsState.submitted();
+          _clearStoredCurrentSurveySubmission();
+        } else {
+          state = SurveyQuestionsState.error(
+            error: NetworkExceptions.getErrorMessage(
+              (result as Failed).exception.actualException,
+            ),
+          );
+        }
+      }
+    }
+  }
 
   void _clearStoredCurrentSurveySubmission() {
     _saveSurveySubmissionUseCase.call(null);

--- a/lib/ui/survey_question/survey_questions_view_model.dart
+++ b/lib/ui/survey_question/survey_questions_view_model.dart
@@ -188,7 +188,7 @@ class SurveyQuestionsViewModel extends StateNotifier<SurveyQuestionsState> {
         submission = _newSurveySubmission(answers);
       } else if (submission.surveyId != _surveyIdValue ||
           _questionNumberValue == 0) {
-        _clearStoredCurrentSurveySubmission();
+        await _clearStoredCurrentSurveySubmission();
         submission = _newSurveySubmission(answers);
       } else {
         submission = _addNewAnswerToSurveySubmission(
@@ -196,7 +196,7 @@ class SurveyQuestionsViewModel extends StateNotifier<SurveyQuestionsState> {
           answers,
         );
       }
-      _saveSurveySubmissionUseCase.call(submission);
+      await _saveSurveySubmissionUseCase.call(submission);
     }
   }
 

--- a/test/mocks/generate_mocks.dart
+++ b/test/mocks/generate_mocks.dart
@@ -10,11 +10,12 @@ import 'package:survey_flutter_ic/usecases/fetch_surveys_use_case.dart';
 import 'package:survey_flutter_ic/usecases/forgot_password_use_case.dart';
 import 'package:survey_flutter_ic/usecases/get_current_survey_use_case.dart';
 import 'package:survey_flutter_ic/usecases/get_survey_details_use_case.dart';
+import 'package:survey_flutter_ic/usecases/get_survey_submission_use_case.dart';
 import 'package:survey_flutter_ic/usecases/login_use_case.dart';
 import 'package:survey_flutter_ic/usecases/save_current_survey_use_case.dart';
-import 'package:survey_flutter_ic/usecases/save_surveys_use_case.dart';
-import 'package:survey_flutter_ic/usecases/get_survey_submission_use_case.dart';
 import 'package:survey_flutter_ic/usecases/save_survey_submission_use_case.dart';
+import 'package:survey_flutter_ic/usecases/save_surveys_use_case.dart';
+import 'package:survey_flutter_ic/usecases/submit_survey_answer_use_case.dart';
 
 @GenerateMocks([
   AuthApiService,
@@ -32,6 +33,7 @@ import 'package:survey_flutter_ic/usecases/save_survey_submission_use_case.dart'
   GetCurrentSurveyUseCase,
   GetSurveySubmissionUseCase,
   SaveSurveySubmissionUseCase,
+  SubmitSurveyAnswerUseCase,
   UseCaseException,
 ])
 main() {

--- a/test/viewmodel/survey_questions_view_model_test.dart
+++ b/test/viewmodel/survey_questions_view_model_test.dart
@@ -21,19 +21,24 @@ void main() {
     late MockGetCurrentSurveyUseCase mockGetCurrentSurveyUseCase;
     late MockGetSurveySubmissionUseCase mockGetSurveySubmissionUseCase;
     late MockSaveSurveySubmissionUseCase mockSaveSurveySubmissionUseCase;
+    late MockSubmitSurveyAnswerUseCase mockSubmitSurveyAnswerUseCase;
     late ProviderContainer container;
 
     setUp(() {
       mockGetCurrentSurveyUseCase = MockGetCurrentSurveyUseCase();
       mockGetSurveySubmissionUseCase = MockGetSurveySubmissionUseCase();
       mockSaveSurveySubmissionUseCase = MockSaveSurveySubmissionUseCase();
+      mockSubmitSurveyAnswerUseCase = MockSubmitSurveyAnswerUseCase();
       container = ProviderContainer(
         overrides: [
-          surveyQuestionsViewModelProvider.overrideWith((ref) =>
-              SurveyQuestionsViewModel(
-                  mockGetCurrentSurveyUseCase,
-                  mockGetSurveySubmissionUseCase,
-                  mockSaveSurveySubmissionUseCase)),
+          surveyQuestionsViewModelProvider.overrideWith(
+            (ref) => SurveyQuestionsViewModel(
+              mockGetCurrentSurveyUseCase,
+              mockGetSurveySubmissionUseCase,
+              mockSaveSurveySubmissionUseCase,
+              mockSubmitSurveyAnswerUseCase,
+            ),
+          ),
         ],
       );
       addTearDown(container.dispose);


### PR DESCRIPTION
- Close #35 

## What happened 👀

- Integrating submit answer submission to BE call

## Insight 📝

- With current implementation, we have to re-render the question widget again with state `submitting` `submitted` `onError`. This will be optimized later.

## Proof Of Work 📹

https://github.com/nimblehq/flutter-ic-david-bruce/assets/25218255/1b248e00-e2fe-4aac-b4e7-18806ca74b97

```
flutter: *** Request ***
flutter: uri: https://survey-api.nimblehq.co/api/v1/responses
flutter: method: POST
flutter: responseType: ResponseType.json
flutter: followRedirects: true
flutter: connectTimeout: 3000
flutter: sendTimeout: 0
flutter: receiveTimeout: 5000
flutter: receiveDataWhenStatusError: true
flutter: extra: {}
flutter: headers:
flutter:  content-type: application/json; charset=utf-8
flutter:  Authorization: Bearer joFR516SsSAbC_utDjUCp29Y5FyLL15_apMV8fNsu60
flutter: data:
flutter: {survey_id: d5de6a8f8f5f1cfe51bc, questions: [{id: d3afbcf2b1d60af845dc, answers: [{id: 037574cb93d16800eecd}]}, {id: 940d229e4cd87cd1e202, answers: [{id: 3f5c5676e40cb185a0e8}]}, {id: ea0555f328b3b0124127, answers: [{id: 534f04bca9d051c8deb3}]}, {id: 16e68f5610ef0e0fa4db, answers: [{id: ae5825c1b2acf846d53a}]}, {id: bab38ad82eaf22afcdfe, answers: [{id: a1079c6457ff9e195314}]}, {id: 85275a0bf28a6f3b1e63, answers: [{id: 8ab9b175d4e906cd9b77}]}, {id: 642770376f7cd0c87d3c, answers: [{id: 002d338bc37f2142ad44}]}, {id: b093a6ad9a6a466fa787, answers: [{id: 54daf66f71cc24161b22}]}, {id: e593b2fa2f81891a2b1e, answers: [{id: 54daf66f71cc24161b22}]}, {id: c3a9b8ce5c2356010703, answers: [{id: 491d49dd6b8174456acf, answer: first name}, {id: 6db6dcae1a6c6644d723, answer: 0988888888}, {id: 575db8c074601994bde3, answer: avc@gmail.com}]}]}
flutter:
flutter: *** Response ***
flutter: uri: https://survey-api.nimblehq.co/api/v1/responses
flutter: statusCode: 201
flutter: headers:
flutter:  connection: keep-alive
flutter:  cache-control: max-age=0, private, must-revalidate
flutter:  date: Mon, 15 May 2023 10:08:00 GMT
flutter:  vary: Accept-Encoding, Origin
flutter:  content-encoding: gzip
flutter:  referrer-policy: strict-origin-when-cross-origin
flutter:  report-to: {"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=TmLqj14XtEbC9oLSl%2Fs80BgIQwVwf%2BdbD88UoZWc9lWx5%2B2uogcCv1tDOqkLaqLVHHtdlaSHF1KUknVfIXGHMt0noyD2Wz5sddP6R46SksGwmQr8Szb%2B%2FwTdEybwWoRc5zi8GRmG%2FviC"}],"group":"cf-nel","max_age":604800}
flutter:  cf-cache-status: DYNAMIC
flutter:  x-permitted-cross-domain-policies: none
flutter:  content-type: application/json; charset=utf-8
flutter:  x-xss-protection: 0
flutter:  server: cloudflare
flutter:  x-request-id: 54ec6619-5356-4a2a-b5e6-e60c62e869d4
flutter:  alt-svc: h3=":443"; ma=86400, h3-29=":443"; ma=86400
flutter:  content-length: 28
flutter:  nel: {"success_fraction":0,"report_to":"cf-nel","max_age":604800}
flutter:  x-download-options: noopen
flutter:  cf-ray: 7c7a93c0f9e60cb7-LAX
flutter:  x-runtime: 0.005886
flutter:  etag: W/"2d498998d16db5a2da888a0327543932"
flutter:  via: 1.1 vegur
flutter:  x-frame-options: SAMEORIGIN
flutter:  x-content-type-options: nosniff
flutter: Response Text:
flutter: {}
```
